### PR TITLE
RND-220 - Add bidirectional character scanning 

### DIFF
--- a/.github/workflows/bidi-scanner.yml
+++ b/.github/workflows/bidi-scanner.yml
@@ -1,0 +1,14 @@
+name: Run Unicode Control Character Scan
+
+on:
+  workflow_call:
+
+jobs:
+  check-for-bidirectional-characters:
+    runs-on: ubuntu-latest
+    steps:
+        # Check out the repo that is calling this action
+      - name: Checkout Repo to Scan
+        uses: actions/checkout@v2
+      - name: Trojan Source Detector
+        uses: haveyoudebuggedit/trojansourcedetector@103b76ee743f7a666fd98dfaa15b4b7e314ca140 #Hash value for v1.1.0

--- a/.github/workflows/repository-scanner.yml
+++ b/.github/workflows/repository-scanner.yml
@@ -1,0 +1,30 @@
+name: Scan Actions
+on:
+  workflow_call:
+  push:
+
+jobs:
+  action-allowedlist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          repository: Ed-Fi-Alliance-OSS/Ed-Fi-Actions
+          ref: SPIKE-BiDirectional-Character-Scanning
+          path: Ed-Fi-Actions
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          path: testing-repo
+      - name: Scan used actions
+        uses: ./Ed-Fi-Actions/action-allowedlist
+        id: scan-action
+  bidi-scanner:
+      runs-on: ubuntu-latest
+      steps:
+        # Check out the repo that is calling this action
+      - name: Checkout Repo to Scan
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Trojan Source Detector
+        uses: haveyoudebuggedit/trojansourcedetector@103b76ee743f7a666fd98dfaa15b4b7e314ca140 #Hash value for v1.1.0

--- a/.github/workflows/repository-scanner.yml
+++ b/.github/workflows/repository-scanner.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-Actions
-          ref: SPIKE-BiDirectional-Character-Scanning
+          ref: RND-220
           path: Ed-Fi-Actions
       - name: Checkout
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846

--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -48,6 +48,10 @@
       "actionVersion": "a71d1eb2c86af85faa8c772c03fb365e377e45ea"
     },
     {
+        "actionLink": "haveyoudebuggedit/trojansourcedetector",
+        "actionVersion": "103b76ee743f7a666fd98dfaa15b4b7e314ca140"
+    },
+    {
       "actionLink": "./action-allowedlist",
       "actionVersion": null
     },
@@ -60,4 +64,3 @@
       "actionVersion": "latest"
     }
   ]
-  

--- a/bidirectional_character_scan/README.md
+++ b/bidirectional_character_scan/README.md
@@ -1,0 +1,66 @@
+# Bidirectional and Allowed Action repository scanning
+
+Scans a repo for hidden unicode bidirectional characters as described in CVE-2021-42694 and detailed at https://trojansource.codes/
+
+This action is paired with the Ed-Fi allowed action scanner as described in this [readme](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Actions/tree/main/action-allowedlist)
+
+## Example usage
+
+Minimal uses expression to use this action:
+
+``` yaml
+- uses: ed-fi-alliance-oss/ed-fi-actions/.github/workflows/repository-scanner.yml
+```
+
+Note: adding the above to an existing workflow will call both the allowed action and bidi scanner on the existing repo
+
+
+```yml
+name: Run Unicode Bidirectional Character Scan
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+   scan-repo:
+    uses: ed-fi-alliance-oss/ed-fi-actions/.github/workflows/repository-scanner.yml
+
+```
+Above is a complete action that once included in the /.github/workflows will checkout and scan the current repo for allowed actions and bidirectional characters
+
+## Outputs
+### bidi-scanner
+If no hidden control characters were found the action will return 'No Errors Found.' and the job will pass. If hidden control characters are found an error similar to the following will be shown and the job will fail
+
+```
+Error: bidirectional control character: Right-to-Left Embedding control character
+bidirectional control character in Extensions/bidirectional_characters_test.cs line 1 column 10 (Right-to-Left Embedding control character)
+```
+
+### AllowedList
+actions: a json string with all the unapproved actions used in the workflows in the repo. The json is in the format:
+
+``` json
+[
+  {
+    "actionLink": "actions/checkout",
+    "actionVersion": "v2"
+  }
+]
+```
+
+Properties:
+|Name|Description|
+|----|-----------|
+|actionLink|The link to the action used in the workflow|
+|actionVersion|The version of the action used in the workflow|
+
+
+## Bidi Scanner Only
+We have also provided an action for bidi scanning seperate from the allowed action scanning, using the following yaml:
+
+```
+- uses: ed-fi-alliance-oss/ed-fi-actions/.github/workflows/bidi-scanner.yml
+```

--- a/bidirectional_character_scan/bidi-scanner.yml
+++ b/bidirectional_character_scan/bidi-scanner.yml
@@ -1,0 +1,14 @@
+name: Run Unicode Control Character Scan
+
+on:
+  workflow_call:
+
+jobs:
+  check-for-bidirectional-characters:
+    runs-on: ubuntu-latest
+    steps:
+        # Check out the repo that is calling this action
+      - name: Checkout Repo to Scan
+        uses: actions/checkout@v2
+      - name: Trojan Source Detector
+        uses: haveyoudebuggedit/trojansourcedetector@103b76ee743f7a666fd98dfaa15b4b7e314ca140 #Hash value for v1.1.0

--- a/bidirectional_character_scan/repository-scanner.yml
+++ b/bidirectional_character_scan/repository-scanner.yml
@@ -1,0 +1,30 @@
+name: Scan Actions
+on:
+  workflow_call:
+  push:
+
+jobs:
+  action-allowedlist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          repository: Ed-Fi-Alliance-OSS/Ed-Fi-Actions
+          ref: RND-220
+          path: Ed-Fi-Actions
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          path: testing-repo
+      - name: Scan used actions
+        uses: ./Ed-Fi-Actions/action-allowedlist
+        id: scan-action
+  bidi-scanner:
+      runs-on: ubuntu-latest
+      steps:
+        # Check out the repo that is calling this action
+      - name: Checkout Repo to Scan
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Trojan Source Detector
+        uses: haveyoudebuggedit/trojansourcedetector@103b76ee743f7a666fd98dfaa15b4b7e314ca140 #Hash value for v1.1.0


### PR DESCRIPTION
included yaml for scanning with the allowed action scanner as well as bidi scanning only. I updated the action-allowedlist.ps1 to handle both the standard working directory and the working directory created from calling the action with the bidi scanner.