### PR TITLE
ODS-5477- Add new download artifact action to approved list

### DIFF
--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -143,5 +143,10 @@
       "actionLink": "nuget/setup-nuget",
       "actionVersion": "b2bc17b761a1d88cab755a776c7922eb26eefbfa",
       "tag": "1.0.6"
+    },
+    {
+      "actionLink": "actions/download-artifact",
+      "actionVersion": "fb598a63ae348fa914e94cd0ff38f362e927b741",
+      "tag": "3.0.0"
     }
   ]


### PR DESCRIPTION
We have an [existing download artifact action](https://github.com/dawidd6/action-download-artifact) in the approved list [here](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Actions/blob/main/action-allowedlist/approved.json#L97), but there is a breaking change in the current version where a workflow must be specified. A PR to make a workflow optional was merged, but a new release has not been created after that merge as of yet.