### PR TITLE
[ODS-5477] - Add repository dispatch action

### DIFF
--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -143,5 +143,10 @@
       "actionLink": "nuget/setup-nuget",
       "actionVersion": "b2bc17b761a1d88cab755a776c7922eb26eefbfa",
       "tag": "1.0.6"
+    },
+    {
+      "actionLink": "actions/download-artifact",
+      "actionVersion": "fb598a63ae348fa914e94cd0ff38f362e927b741",
+      "tag": "3.0.0"
     }
   ]

--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -145,8 +145,8 @@
       "tag": "1.0.6"
     },
     {
-      "actionLink": "actions/download-artifact",
-      "actionVersion": "fb598a63ae348fa914e94cd0ff38f362e927b741",
-      "tag": "3.0.0"
+      "actionLink": "peter-evans/repository-dispatch",
+      "actionVersion": "11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5",
+      "tag": "2.0.0"
     }
   ]


### PR DESCRIPTION
This action is being used so that when a commit is pushed to the ODS repo, it can then trigger the InitDev workflows that are being setup in the Implementation Repo. You can see it being referenced in [this PR](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS/pull/551).

Here is a link to the action's repo https://github.com/peter-evans/repository-dispatch