### PR TITLE
Adding powershell analyzer to list of approved actions

### DIFF
--- a/.github/workflows/powershell-analyzer.yml
+++ b/.github/workflows/powershell-analyzer.yml
@@ -42,7 +42,7 @@ jobs:
           sarif_file: ./results.sarif
 
       - name: Upload SARIF Result
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
             name: analysis-result
             path: ./results.sarif

--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -120,6 +120,18 @@
       "actionVersion": null
     },
     {
+        "actionLink": "./powershell-analyzer",
+        "actionVersion": null
+    },
+    {
+        "actionLink": "Ed-Fi-Alliance-OSS/Ed-Fi-Actions/powershell-analyzer",
+        "actionVersion": "latest"
+      },
+    {
+        "actionLink": "./Ed-Fi-Actions/powershell-analyzer",
+        "actionVersion": null
+    },
+    {
       "actionLink": "github/codeql-action/init",
       "actionVersion": "1fae5bf71b0ecdc7d0a2ef0d0c28409d99693966",
       "tag": "2.9.2"


### PR DESCRIPTION
- Update version of upload-artifacts to use approved one
- Add powershell analyzer and all the ways of referencing it to the list of approved actions