### PR TITLE
Fixing package name

### DIFF
--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -99,7 +99,7 @@
         "tag": "v2.19.0"
     },
     {
-        "actionLink": "dawidd6/action-download-artifact",
+        "actionLink": "actions/download-artifact",
         "actionVersion": "fb598a63ae348fa914e94cd0ff38f362e927b741",
         "tag": "v3.0.0"
     },


### PR DESCRIPTION
Approved list had dawidd6/action-download-artifact but was missing actions/download-artifact. 

It can be worth to come back and review if the first action has any additonal funtionality that the "official" does not