### PR TITLE
Update the allowed version of dorny/test-reporter

### DIFF
--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload Test Results
-        uses: dorny/test-reporter@0d00bb14cb0cc2c9b8985df6e81dd333188224e1 #v1.5.0
+        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 #v1.6.0
         with:
           artifact: powershell-analyzer-test-results
           name: Tests Results

--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -182,8 +182,8 @@
     },
     {
         "actionLink": "dorny/test-reporter",
-        "actionVersion": "0d00bb14cb0cc2c9b8985df6e81dd333188224e1",
-        "tag": "1.5.0"
+        "actionVersion": "c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226",
+        "tag": "1.6.0"
     },
     {
         "actionLink": "nuget/setup-nuget",


### PR DESCRIPTION
This newer version has support for NodeJs 16. Old version now gives you deprecation warnings on your Actions jobs, [example](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-AdminAPI/actions/runs/3282936539).