### PR TITLE
ODS-5609 - Add new version of test reporter to approved list

### DIFF
--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -186,6 +186,11 @@
         "tag": "1.5.0"
     },
     {
+        "actionLink": "dorny/test-reporter",
+        "actionVersion": "c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226",
+        "tag": "1.6.0"
+    },
+    {
         "actionLink": "nuget/setup-nuget",
         "actionVersion": "b2bc17b761a1d88cab755a776c7922eb26eefbfa",
         "tag": "1.0.6"


### PR DESCRIPTION
A 1.6 release was created for the test reporter to update its dependencies and resolve a vulnerability, so we'd like to use this in the Implementation and ODS repo builds that run tests to report on their results.