### PR TITLE
Updating codeql (deprecate older versions)

### DIFF
--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -263,47 +263,71 @@
     {
         "actionLink": "github/codeql-action/init",
         "actionVersion": "1fae5bf71b0ecdc7d0a2ef0d0c28409d99693966",
-        "tag": "codeql-bundle-20220512"
+        "tag": "codeql-bundle-20220512",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/analyze",
         "actionVersion": "1fae5bf71b0ecdc7d0a2ef0d0c28409d99693966",
-        "tag": "codeql-bundle-20220512"
+        "tag": "codeql-bundle-20220512",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/upload-sarif",
         "actionVersion": "1fae5bf71b0ecdc7d0a2ef0d0c28409d99693966",
-        "tag": "codeql-bundle-20220512"
+        "tag": "codeql-bundle-20220512",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/init",
         "actionVersion": "8aff97f12c99086bdb92ff62ae06dbbcdf07941b",
-        "tag": "codeql-bundle-20221105"
+        "tag": "codeql-bundle-20221105",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/analyze",
         "actionVersion": "8aff97f12c99086bdb92ff62ae06dbbcdf07941b",
-        "tag": "codeql-bundle-20221105"
+        "tag": "codeql-bundle-20221105",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/upload-sarif",
         "actionVersion": "8aff97f12c99086bdb92ff62ae06dbbcdf07941b",
-        "tag": "codeql-bundle-20221105"
+        "tag": "codeql-bundle-20221105",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/init",
         "actionVersion": "896079047b4bb059ba6f150a5d87d47dde99e6e5",
-        "tag": "codeql-bundle-20221211"
+        "tag": "codeql-bundle-20221211",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/analyze",
         "actionVersion": "896079047b4bb059ba6f150a5d87d47dde99e6e5",
-        "tag": "codeql-bundle-20221211"
+        "tag": "codeql-bundle-20221211",
+        "deprecated": true
     },
     {
         "actionLink": "github/codeql-action/upload-sarif",
         "actionVersion": "896079047b4bb059ba6f150a5d87d47dde99e6e5",
-        "tag": "codeql-bundle-20221211"
+        "tag": "codeql-bundle-20221211",
+        "deprecated": true
+    },
+    {
+      "actionLink": "github/codeql-action/init",
+      "actionVersion": "df32e399139a3050671466d7d9b3cbacc1cfd034",
+      "tag": "codeql-bundle-v2.15.2"
+    },
+    {
+        "actionLink": "github/codeql-action/analyze",
+        "actionVersion": "df32e399139a3050671466d7d9b3cbacc1cfd034",
+        "tag": "codeql-bundle-v2.15.2"
+    },
+    {
+        "actionLink": "github/codeql-action/upload-sarif",
+        "actionVersion": "df32e399139a3050671466d7d9b3cbacc1cfd034",
+        "tag": "codeql-bundle-v2.15.2"
     },
     {
         "actionLink": "actions/dependency-review-action",


### PR DESCRIPTION
- Approved versions of CodeQL are over a year old and there have been multiple updates since.