### PR TITLE
Deprecations should not cause exit(1)

### DIFF
--- a/action-allowedlist/action_allowedlist/actions_parser.py
+++ b/action-allowedlist/action_allowedlist/actions_parser.py
@@ -114,7 +114,6 @@ def invoke_validate_actions(approved_path, actions_configuration):
             if approved_output[0].get("deprecated", False):
                 print(f"Using a deprecated version of {action['actionLink']}")
                 num_deprecated += 1
-                found = True
         else:
             print(
                 f"::debug::Output versions not approved: {action['actionLink']} version {action['actionVersion']}"


### PR DESCRIPTION
https://github.com/Ed-Fi-Exchange-OSS/Meadowlark/actions/runs/10081499308/job/27873653387

This workflow has some deprecated actions, and the job failed. This PR should fix to prevent this from failing.