### PR TITLE
Approved version updates for 3rd party actions

### DIFF
--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -722,10 +722,10 @@
     "deprecated": true
   },
   {
-  "actionLink": "docker/setup-buildx-action",
-  "actionVersion": "6524bf65af31da8d45b59e8c27de4bd072b392f5",
-  "tag": "v3.8.0"
-},
+    "actionLink": "docker/setup-buildx-action",
+    "actionVersion": "6524bf65af31da8d45b59e8c27de4bd072b392f5",
+    "tag": "v3.8.0"
+  },
   {
     "actionLink": "docker/login-action",
     "actionVersion": "f4ef78c080cd8ba55a85445d5b36e214a81df20a",
@@ -738,10 +738,11 @@
     "tag": "v3.0.0",
     "deprecated": true
   },
-  {    "actionLink": "docker/login-action",
-  "actionVersion": "9780b0c442fbb1117ed29e0efdff1e18412f7567",
-  "tag": "v3.3.0"
-},
+  {
+    "actionLink": "docker/login-action",
+    "actionVersion": "9780b0c442fbb1117ed29e0efdff1e18412f7567",
+    "tag": "v3.3.0"
+  },
   {
     "actionLink": "docker/metadata-action",
     "actionVersion": "507c2f2dc502c992ad446e3d7a5dfbe311567a96",
@@ -753,11 +754,12 @@
     "actionVersion": "96383f45573cb7f253c731d3b3ab81c87ef81934",
     "tag": "v5.0.0",
     "deprecated": true
-  },{
-  "actionLink": "docker/metadata-action",
-  "actionVersion": "369eb591f429131d6889c46b94e711f089e6ca96",
-  "tag": "v5.6.1"
-},
+  },
+  {
+    "actionLink": "docker/metadata-action",
+    "actionVersion": "369eb591f429131d6889c46b94e711f089e6ca96",
+    "tag": "v5.6.1"
+  },
   {
     "actionLink": "docker/build-push-action",
     "actionVersion": "3b5e8027fcad23fda98b2e3ac259d8d67585f671",

--- a/action-allowedlist/approved.json
+++ b/action-allowedlist/approved.json
@@ -38,12 +38,18 @@
   {
     "actionLink": "actions/checkout",
     "actionVersion": "8ade135a41bc03ea155e62e844d188df1ea18608",
-    "tag": "v4.1.0"
+    "tag": "v4.1.0",
+    "deprecated": true
   },
   {
     "actionLink": "actions/checkout",
     "actionVersion": "b4ffde65f46336ab88eb53be808477a3936bae11",
     "tag": "v4.1.1"
+  },
+  {
+    "actionLink": "actions/checkout",
+    "actionVersion": "11bd71901bbe5b1630ceea73d27597364c9af683",
+    "tag": "v4.2.2"
   },
   {
     "actionLink": "actions/cache",
@@ -72,7 +78,13 @@
   {
     "actionLink": "actions/cache",
     "actionVersion": "13aacd865c20de90d75de3b17ebe84f7a17d57d2",
-    "tag": "v4.0.0"
+    "tag": "v4.0.0",
+    "deprecated": true
+  },
+  {
+    "actionLink": "actions/cache",
+    "actionVersion": "1bd1e32a3bdc45362d1e726936510720a7c30a57",
+    "tag": "v4.2"
   },
   {
     "actionLink": "actions/cache",
@@ -86,15 +98,26 @@
     "deprecated": true
   },
   {
+    "actionLink": "actions/cache/save",
+    "actionVersion": "1bd1e32a3bdc45362d1e726936510720a7c30a57",
+    "tag": "v4.2"
+  },
+  {
     "actionLink": "actions/cache/restore",
     "actionVersion": "58c146cc91c5b9e778e71775dfe9bf1442ad9a12",
     "tag": "v3.2.3",
     "deprecated": true
   },
   {
+    "actionLink": "actions/cache/restore",
+    "actionVersion": "1bd1e32a3bdc45362d1e726936510720a7c30a57",
+    "tag": "v4.2"
+  },
+  {
     "actionLink": "actions/create-release",
     "actionVersion": "0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e",
-    "tag": "v1.1.4"
+    "tag": "v1.1.4",
+    "deprecated": true
   },
   {
     "actionLink": "actions/upload-release-asset",
@@ -128,7 +151,13 @@
   {
     "actionLink": "actions/setup-dotnet",
     "actionVersion": "607fce577a46308457984d59e4954e075820f10a",
-    "tag": "v3.0.3"
+    "tag": "v3.0.3",
+    "deprecated": true
+  },
+  {
+    "actionLink": "actions/setup-dotnet",
+    "actionVersion": "87b7050bc53ea08284295505d98d2aa94301e852",
+    "tag": "v4.2"
   },
   {
     "actionLink": "actions/setup-python",
@@ -148,8 +177,20 @@
     "tag": "v5.1.0"
   },
   {
+    "actionLink": "actions/setup-python",
+    "actionVersion": "0b93645e9fea7318ecaed2b359559ac225c90a2b",
+    "tag": "v5.3"
+  },
+  {
     "actionLink": "Gr1N/setup-poetry",
-    "actionVersion": "462ac83c852d49e282a1233c4c24c5411696e7c7"
+    "actionVersion": "462ac83c852d49e282a1233c4c24c5411696e7c7",
+    "tag": "v4",
+    "deprecated": true
+  },
+  {
+    "actionLink": "Gr1N/setup-poetry",
+    "actionVersion": "48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec",
+    "tag": "v9"
   },
   {
     "actionLink": "actions/upload-artifact",
@@ -187,39 +228,66 @@
     "tag": "v4.3.0"
   },
   {
+    "actionLink": "actions/upload-artifact",
+    "actionVersion": "6f51ac03b9356f520e9adb1b1b7802705f340c2b",
+    "tag": "v4.5"
+  },
+  {
     "actionLink": "github/super-linter",
     "actionVersion": "431ee7836e8cdce5a460b0db682d9169563d919b",
-    "tag": "v4.9.3"
+    "tag": "v4.9.3",
+    "deprecated": true
+  },
+  {
+    "actionLink": "github/super-linter",
+    "actionVersion": "b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1",
+    "tag": "v7"
   },
   {
     "actionLink": "dawidd6/action-download-artifact",
     "actionVersion": "1cf11afe3f1874cee82a8d5a2b45c0fd63f0fa22",
-    "tag": "v2.19.0"
+    "tag": "v2.19.0",
+    "deprecated": true
   },
   {
     "actionLink": "dawidd6/action-download-artifact",
     "actionVersion": "246dbf436b23d7c49e21a7ab8204ca9ecd1fe615",
-    "tag": "v2.27.0"
+    "tag": "v2.27.0",
+    "deprecated": true
   },
   {
     "actionLink": "dawidd6/action-download-artifact",
     "actionVersion": "71072fbb1229e1317f1a8de6b04206afb461bd67",
-    "tag": "v3.1.2"
+    "tag": "v3.1.2",
+    "deprecated": true
+  },
+  {
+    "actionLink": "dawidd6/action-download-artifact",
+    "actionVersion": "80620a5d27ce0ae443b965134db88467fc607b43",
+    "tag": "v7"
   },
   {
     "actionLink": "actions/download-artifact",
     "actionVersion": "fb598a63ae348fa914e94cd0ff38f362e927b741",
-    "tag": "v3.0.0"
+    "tag": "v3.0.0",
+    "deprecated": true
   },
   {
     "actionLink": "actions/download-artifact",
     "actionVersion": "9bc31d5ccc31df68ecc42ccf4149144866c47d8a",
-    "tag": "v3.0.2"
+    "tag": "v3.0.2",
+    "deprecated": true
   },
   {
     "actionLink": "actions/download-artifact",
     "actionVersion": "6b208ae046db98c579e8a3aa621ab581ff575935",
-    "tag": "v4.1.1"
+    "tag": "v4.1.1",
+    "deprecated": true
+  },
+  {
+    "actionLink": "actions/download-artifact",
+    "actionVersion": "fa0a91b85d4f404e444e00e005971372dc801d16",
+    "tag": "v4.1.8"
   },
   {
     "actionLink": "actions/setup-node",
@@ -242,12 +310,18 @@
   {
     "actionLink": "actions/setup-node",
     "actionVersion": "8f152de45cc393bb48ce5d89d36b731f54556e65",
-    "tag": "v4.0.0"
+    "tag": "v4.0.0",
+    "deprecated": true
   },
   {
     "actionLink": "actions/setup-node",
     "actionVersion": "60edb5dd545a775178f52524783378180af0d1f8",
     "tag": "v4.0.2"
+  },
+  {
+    "actionLink": "actions/setup-node",
+    "actionVersion": "39370e3970a6d050c480ffad4ff0ed4d3fdee5af",
+    "tag": "v4.1.0"
   },
   {
     "actionLink": "./action-allowedlist",
@@ -271,7 +345,8 @@
   },
   {
     "actionLink": "Ed-Fi-Alliance-OSS/Ed-Fi-Actions/repository-scanner",
-    "actionVersion": "latest"
+    "actionVersion": "latest",
+    "deprecated": true
   },
   {
     "actionLink": "Ed-Fi-Alliance-OSS/Ed-Fi-Actions/repository-scanner",
@@ -283,7 +358,8 @@
   },
   {
     "actionLink": "Ed-Fi-Alliance-OSS/Ed-Fi-Actions/action-allowedlist",
-    "actionVersion": "latest"
+    "actionVersion": "latest",
+    "deprecated": true
   },
   {
     "actionLink": "Ed-Fi-Alliance-OSS/Ed-Fi-Actions/action-allowedlist",
@@ -394,6 +470,21 @@
     "tag": "codeql-bundle-v2.16.2"
   },
   {
+    "actionLink": "github/codeql-action/init",
+    "actionVersion": "3096afedf9873361b2b2f65e1445b13272c83eb8",
+    "tag": "v2.20.0"
+  },
+  {
+    "actionLink": "github/codeql-action/analyze",
+    "actionVersion": "3096afedf9873361b2b2f65e1445b13272c83eb8",
+    "tag": "v2.20.0"
+  },
+  {
+    "actionLink": "github/codeql-action/upload-sarif",
+    "actionVersion": "3096afedf9873361b2b2f65e1445b13272c83eb8",
+    "tag": "v2.20.0"
+  },
+  {
     "actionLink": "actions/dependency-review-action",
     "actionVersion": "a9c83d3af6b9031e20feba03b904645bb23d1dab",
     "tag": "1.0.2",
@@ -408,32 +499,42 @@
   {
     "actionLink": "actions/dependency-review-action",
     "actionVersion": "11310527b429536e263dc6cc47873e608189ba21",
-    "tag": "3.0.1"
+    "tag": "3.0.1",
+    "deprecated": true
   },
   {
     "actionLink": "actions/dependency-review-action",
     "actionVersion": "0ff3da6f81b812d4ec3cf37a04e2308c7a723730",
-    "tag": "3.0.2"
+    "tag": "3.0.2",
+    "deprecated": true
   },
   {
     "actionLink": "actions/dependency-review-action",
     "actionVersion": "c090f4e553673e6e505ea70d6a95362ee12adb94",
-    "tag": "3.0.3"
+    "tag": "3.0.3",
+    "deprecated": true
   },
   {
     "actionLink": "actions/dependency-review-action",
     "actionVersion": "7bbfa034e752445ea40215fff1c3bf9597993d3f",
-    "tag": "3.1.3"
+    "tag": "3.1.3",
+    "deprecated": true
   },
   {
     "actionLink": "actions/dependency-review-action",
     "actionVersion": "4901385134134e04cec5fbe5ddfe3b2c5bd5d976",
-    "tag": "4.0.0"
+    "tag": "4.0.0",
+    "deprecated": true
   },
   {
     "actionLink": "actions/dependency-review-action",
     "actionVersion": "9129d7d40b8c12c1ed0f60400d00c92d437adcce",
     "tag": "4.1.3"
+  },
+  {
+    "actionLink": "actions/dependency-review-action",
+    "actionVersion": "3b139cfc5fae8b618d3eae3675e383bb1769c019",
+    "tag": "4.5.0"
   },
   {
     "actionLink": "dorny/test-reporter",
@@ -444,7 +545,8 @@
   {
     "actionLink": "dorny/test-reporter",
     "actionVersion": "c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226",
-    "tag": "1.6.0"
+    "tag": "1.6.0",
+    "deprecated": true
   },
   {
     "actionLink": "dorny/test-reporter",
@@ -452,24 +554,42 @@
     "tag": "1.8.0"
   },
   {
+    "actionLink": "dorny/test-reporter",
+    "actionVersion": "31a54ee7ebcacc03a09ea97a7e5465a47b84aea5",
+    "tag": "1.9.1"
+  },
+  {
     "actionLink": "nuget/setup-nuget",
     "actionVersion": "b2bc17b761a1d88cab755a776c7922eb26eefbfa",
-    "tag": "1.0.6"
+    "tag": "1.0.6",
+    "deprecated": true
   },
   {
     "actionLink": "nuget/setup-nuget",
     "actionVersion": "fd9fffd6ca4541cf4152a9565835ca1a88a6eb37",
-    "tag": "v1.1.1"
+    "tag": "v1.1.1",
+    "deprecated": true
   },
   {
     "actionLink": "nuget/setup-nuget",
     "actionVersion": "a21f25cd3998bf370fde17e3f1b4c12c175172f9",
-    "tag": "v2.0.0"
+    "tag": "v2.0.0",
+    "deprecated": true
+  },
+  {
+    "actionLink": "nuget/setup-nuget",
+    "actionVersion": "323ab0502cd38fdc493335025a96c8fdb0edc71f",
+    "tag": "v2.0.1"
   },
   {
     "actionLink": "peter-evans/repository-dispatch",
     "actionVersion": "11ba7d3f32dc7cc919d1c43f1fec1c05260c26b5",
     "tag": "2.0.0"
+  },
+  {
+    "actionLink": "peter-evans/repository-dispatch",
+    "actionVersion": "ff45666b9427631e3450c54a1bcbee4d9ff4d7c0",
+    "tag": "v3.0.0"
   },
   {
     "actionLink": "crazy-max/ghaction-import-gpg",
@@ -483,8 +603,14 @@
     "tag": "6.0.0"
   },
   {
+    "actionLink": "crazy-max/ghaction-import-gpg",
+    "actionVersion": "cb9bde2e2525e640591a934b1fd28eef1dcaf5e5",
+    "tag": "6.2.0"
+  },
+  {
     "actionLink": "slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact",
-    "actionVersion": "1d646d70aeba1516af69fb0ef48206580122449b"
+    "actionVersion": "1d646d70aeba1516af69fb0ef48206580122449b",
+    "deprecated": true
   },
   {
     "actionLink": "slsa-framework/slsa-github-generator/.github/actions/secure-download-artifact",
@@ -527,6 +653,11 @@
     "tag": "3.17"
   },
   {
+    "actionLink": "mxschmitt/action-tmate",
+    "actionVersion": "e5c7151931ca95bad1c6f4190c730ecf8c7dde48",
+    "tag": "3.19"
+  },
+  {
     "actionLink": "hadolint/hadolint-action",
     "actionVersion": "54c9adbab1582c2ef04b2016b760714a4bfde3cf",
     "tag": "3.1.0"
@@ -558,6 +689,11 @@
     "tag": "1.14.0"
   },
   {
+    "actionLink": "Codex-/return-dispatch",
+    "actionVersion": "2410062d00e50fbdc50dd9065a4e5f673e2455d3",
+    "tag": "v2.0.3"
+  },
+  {
     "actionLink": "Ed-Fi-Actions/bidi-scanner",
     "actionVersion": "main"
   },
@@ -582,8 +718,14 @@
   {
     "actionLink": "docker/setup-buildx-action",
     "actionVersion": "f95db51fddba0c2d1ec667646a06c2ce06100226",
-    "tag": "v3.0.0"
+    "tag": "v3.0.0",
+    "deprecated": true
   },
+  {
+  "actionLink": "docker/setup-buildx-action",
+  "actionVersion": "6524bf65af31da8d45b59e8c27de4bd072b392f5",
+  "tag": "v3.8.0"
+},
   {
     "actionLink": "docker/login-action",
     "actionVersion": "f4ef78c080cd8ba55a85445d5b36e214a81df20a",
@@ -593,8 +735,13 @@
   {
     "actionLink": "docker/login-action",
     "actionVersion": "343f7c4344506bcbf9b4de18042ae17996df046d",
-    "tag": "v3.0.0"
+    "tag": "v3.0.0",
+    "deprecated": true
   },
+  {    "actionLink": "docker/login-action",
+  "actionVersion": "9780b0c442fbb1117ed29e0efdff1e18412f7567",
+  "tag": "v3.3.0"
+},
   {
     "actionLink": "docker/metadata-action",
     "actionVersion": "507c2f2dc502c992ad446e3d7a5dfbe311567a96",
@@ -604,8 +751,13 @@
   {
     "actionLink": "docker/metadata-action",
     "actionVersion": "96383f45573cb7f253c731d3b3ab81c87ef81934",
-    "tag": "v5.0.0"
-  },
+    "tag": "v5.0.0",
+    "deprecated": true
+  },{
+  "actionLink": "docker/metadata-action",
+  "actionVersion": "369eb591f429131d6889c46b94e711f089e6ca96",
+  "tag": "v5.6.1"
+},
   {
     "actionLink": "docker/build-push-action",
     "actionVersion": "3b5e8027fcad23fda98b2e3ac259d8d67585f671",
@@ -615,7 +767,13 @@
   {
     "actionLink": "docker/build-push-action",
     "actionVersion": "0565240e2d4ab88bba5387d719585280857ece09",
-    "tag": "v5.0.0"
+    "tag": "v5.0.0",
+    "deprecated": true
+  },
+  {
+    "actionLink": "docker/build-push-action",
+    "actionVersion": "b32b51a8eda65d6793cd0494a773d4f6bcef32dc",
+    "tag": "v6.11.0"
   },
   {
     "actionLink": "docker/scout-action",
@@ -628,6 +786,11 @@
     "tag": "v1.5.0"
   },
   {
+    "actionLink": "docker/scout-action",
+    "actionVersion": "b23590dc1e4d09febc00cfcbc51e9e8c0f7ee9f3",
+    "tag": "v1.16.1"
+  },
+  {
     "actionLink": "ahmadnassri/action-workflow-run-wait",
     "actionVersion": "2aa3d9e1a12ecaaa9908e368eaf2123bb084323e",
     "tag": "v1.4.4"
@@ -636,6 +799,11 @@
     "actionLink": "planetscale/ghcommit-action",
     "actionVersion": "4131649dbf2fdf1eb34421702972a5af7b0a8731",
     "tag": "v0.1.18"
+  },
+  {
+    "actionLink": "planetscale/ghcommit-action",
+    "actionVersion": "d4176bfacef926cc2db351eab20398dfc2f593b5",
+    "tag": "v0.2.0"
   },
   {
     "actionLink": "EnricoMi/publish-unit-test-result-action",
@@ -653,6 +821,11 @@
     "tag": "v2.3.1"
   },
   {
+    "actionLink": "ossf/scorecard-action",
+    "actionVersion": "62b2cac7ed8198b15735ed49ab1e5cf35480ba46",
+    "tag": "v2.4.0"
+  },
+  {
     "actionLink": "microsoft/setup-msbuild",
     "actionVersion": "6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce",
     "tag": "v2.0.0"
@@ -663,9 +836,19 @@
     "tag": "v1.26.0"
   },
   {
+    "actionLink": "slackapi/slack-github-action",
+    "actionVersion": "485a9d42d3a73031f12ec201c457e2162c45d02d",
+    "tag": "v2.0.0"
+  },
+  {
     "actionLink": "actions/setup-java",
     "actionVersion": "99b8673ff64fbf99d8d325f52d9a5bdedb8483e9",
     "tag": "v4.2.1"
+  },
+  {
+    "actionLink": "actions/setup-java",
+    "actionVersion": "7a6d8a8234af8eb26422e24e3006232cccaa061b",
+    "tag": "v4.6.0"
   },
   {
     "actionLink": "gradle/actions/setup-gradle",
@@ -673,9 +856,19 @@
     "tag": "v3.5.0"
   },
   {
+    "actionLink": "gradle/actions/setup-gradle",
+    "actionVersion": "0bdd871935719febd78681f197cd39af5b6e16a6",
+    "tag": "v4.2.2"
+  },
+  {
     "actionLink": "gradle/actions/dependency-submission",
     "actionVersion": "d9c87d481d55275bb5441eef3fe0e46805f9ef70",
     "tag": "v3.5.0"
+  },
+  {
+    "actionLink": "gradle/actions/dependency-submission",
+    "actionVersion": "0bdd871935719febd78681f197cd39af5b6e16a6",
+    "tag": "v4.2.2"
   },
   {
     "actionLink": "softprops/action-gh-release",
@@ -683,14 +876,30 @@
     "tag": "v2.0.8"
   },
   {
+    "actionLink": "softprops/action-gh-release",
+    "actionVersion": "c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda",
+    "tag": "v2.1.1"
+  },
+  {
     "actionLink": "anchore/sbom-action",
     "actionVersion": "61119d458adab75f756bc0b9e4bde25725f86a7a",
-    "tag": "0.17.2"
+    "tag": "0.17.2",
+    "deprecated": true
+  },
+  {
+    "actionLink": "anchore/sbom-action",
+    "actionVersion": "df80a981bc6edbc4e220a492d3cbe9f5547a6e75",
+    "tag": "0.17.9"
   },
   {
     "actionLink": "actions/attest-sbom",
     "actionVersion": "5026d3663739160db546203eeaffa6aa1c51a4d6",
     "tag": "1.4.1"
+  },
+  {
+    "actionLink": "actions/attest-sbom",
+    "actionVersion": "cbfd0027ae731a5892db25ecd226930d7ffd19eb",
+    "tag": "2.1.0"
   },
   {
     "actionLink": "actions/upload-pages-artifact",
@@ -706,5 +915,10 @@
     "actionLink": "hashicorp/setup-terraform",
     "actionVersion": "633666f66e0061ca3b725c73b2ec20cd13a8fdd1",
     "tag": "2.0.3"
+  },
+  {
+    "actionLink": "hashicorp/setup-terraform",
+    "actionVersion": "b9cd54a3c349d3f38e8881555d616ced269862dd",
+    "tag": "v3.1.2"
   }
 ]


### PR DESCRIPTION
Only adds more versions, without removing anything. Marks additional older versions as deprecated when there is a patch release or multiple newer feature releases.